### PR TITLE
replace deprecated RED.events nodes-started with flows:started

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-state-machine",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A Node Red node for implementing a finite state machine.",
   "dependencies": {
     "javascript-state-machine": "3.*"

--- a/state-machine.js
+++ b/state-machine.js
@@ -95,10 +95,10 @@ module.exports = function(RED) {
             }
         }
 
-        RED.events.on("nodes-started", node.startup);
+        RED.events.on("flows:started", node.startup);
 
         node.on('close', function() {
-            RED.events.removeListener("nodes-started", node.startup);
+            RED.events.removeListener("flows:started", node.startup);
         });
 
         node.on('input', function(msg) {


### PR DESCRIPTION
Update code to eliminate `[warn] [RED.events] Deprecated use of "nodes-started" event` error message on Node-RED startup and bump version to 1.2.1.